### PR TITLE
Remove dfs_samba4 from share-smb.conf

### DIFF
--- a/conf/share-smb.conf
+++ b/conf/share-smb.conf
@@ -7,7 +7,7 @@
    valid users = @samba.share
    create mask = 0660
    directory mask = 770
-   vfs objects = dfs_samba4 acl_xattr recycle
+   vfs objects = acl_xattr recycle
    recycle:repository = .recycle
    recycle:keeptree = yes
    recycle:versions = yes


### PR DESCRIPTION
## Problem

- Fix #9 

## Solution

- Remove the `dfs_samba4` parameter value from `/etc/samba/smb.conf.d/share-smb.conf`

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

