### PR TITLE
[fix] Avoid perf issue due to access error on deleted directory tree …

### DIFF
--- a/ALL_README.md
+++ b/ALL_README.md
@@ -6,5 +6,7 @@
 - [Lire le README en français](README_fr.md)
 - [Le o README en galego](README_gl.md)
 - [Baca README dalam bahasa bahasa Indonesia](README_id.md)
+- [Lees de README in het Nederlands](README_nl.md)
+- [Przeczytaj README w języku polski](README_pl.md)
 - [Прочитать README на русский](README_ru.md)
 - [阅读中文（简体）的 README](README_zh_Hans.md)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ It shall NOT be edited by hand.
 
 # Samba for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/samba.svg)](https://ci-apps.yunohost.org/ci/apps/samba/) ![Working status](https://ci-apps.yunohost.org/ci/badges/samba.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/samba.maintain.svg)
+[![Integration level](https://apps.yunohost.org/badge/integration/samba)](https://ci-apps.yunohost.org/ci/apps/samba/)
+![Working status](https://apps.yunohost.org/badge/state/samba)
+![Maintenance status](https://apps.yunohost.org/badge/maintained/samba)
 
 [![Install Samba with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=samba)
 

--- a/README_es.md
+++ b/README_es.md
@@ -5,7 +5,9 @@ No se debe editar a mano.
 
 # Samba para Yunohost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/samba.svg)](https://ci-apps.yunohost.org/ci/apps/samba/) ![Estado funcional](https://ci-apps.yunohost.org/ci/badges/samba.status.svg) ![Estado En Mantención](https://ci-apps.yunohost.org/ci/badges/samba.maintain.svg)
+[![Nivel de integración](https://apps.yunohost.org/badge/integration/samba)](https://ci-apps.yunohost.org/ci/apps/samba/)
+![Estado funcional](https://apps.yunohost.org/badge/state/samba)
+![Estado En Mantención](https://apps.yunohost.org/badge/maintained/samba)
 
 [![Instalar Samba con Yunhost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=samba)
 
@@ -36,7 +38,7 @@ This package allows you to create directories reachable on a private network.
 
 ## Información para desarrolladores
 
-Por favor enviar sus correcciones a la [`branch testing`](https://github.com/YunoHost-Apps/samba_ynh/tree/testing
+Por favor enviar sus correcciones a la [rama `testing`](https://github.com/YunoHost-Apps/samba_ynh/tree/testing).
 
 Para probar la rama `testing`, sigue asÍ:
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -5,7 +5,9 @@ EZ editatu eskuz.
 
 # Samba YunoHost-erako
 
-[![Integrazio maila](https://dash.yunohost.org/integration/samba.svg)](https://ci-apps.yunohost.org/ci/apps/samba/) ![Funtzionamendu egoera](https://ci-apps.yunohost.org/ci/badges/samba.status.svg) ![Mantentze egoera](https://ci-apps.yunohost.org/ci/badges/samba.maintain.svg)
+[![Integrazio maila](https://apps.yunohost.org/badge/integration/samba)](https://ci-apps.yunohost.org/ci/apps/samba/)
+![Funtzionamendu egoera](https://apps.yunohost.org/badge/state/samba)
+![Mantentze egoera](https://apps.yunohost.org/badge/maintained/samba)
 
 [![Instalatu Samba YunoHost-ekin](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=samba)
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,7 +5,9 @@ Il NE doit PAS être modifié à la main.
 
 # Samba pour YunoHost
 
-[![Niveau d’intégration](https://dash.yunohost.org/integration/samba.svg)](https://ci-apps.yunohost.org/ci/apps/samba/) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/samba.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/samba.maintain.svg)
+[![Niveau d’intégration](https://apps.yunohost.org/badge/integration/samba)](https://ci-apps.yunohost.org/ci/apps/samba/)
+![Statut du fonctionnement](https://apps.yunohost.org/badge/state/samba)
+![Statut de maintenance](https://apps.yunohost.org/badge/maintained/samba)
 
 [![Installer Samba avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=samba)
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -5,7 +5,9 @@ NON debe editarse manualmente.
 
 # Samba para YunoHost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/samba.svg)](https://ci-apps.yunohost.org/ci/apps/samba/) ![Estado de funcionamento](https://ci-apps.yunohost.org/ci/badges/samba.status.svg) ![Estado de mantemento](https://ci-apps.yunohost.org/ci/badges/samba.maintain.svg)
+[![Nivel de integración](https://apps.yunohost.org/badge/integration/samba)](https://ci-apps.yunohost.org/ci/apps/samba/)
+![Estado de funcionamento](https://apps.yunohost.org/badge/state/samba)
+![Estado de mantemento](https://apps.yunohost.org/badge/maintained/samba)
 
 [![Instalar Samba con YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=samba)
 

--- a/README_id.md
+++ b/README_id.md
@@ -5,7 +5,9 @@ Ini TIDAK boleh diedit dengan tangan.
 
 # Samba untuk YunoHost
 
-[![Tingkat integrasi](https://dash.yunohost.org/integration/samba.svg)](https://ci-apps.yunohost.org/ci/apps/samba/) ![Status kerja](https://ci-apps.yunohost.org/ci/badges/samba.status.svg) ![Status pemeliharaan](https://ci-apps.yunohost.org/ci/badges/samba.maintain.svg)
+[![Tingkat integrasi](https://apps.yunohost.org/badge/integration/samba)](https://ci-apps.yunohost.org/ci/apps/samba/)
+![Status kerja](https://apps.yunohost.org/badge/state/samba)
+![Status pemeliharaan](https://apps.yunohost.org/badge/maintained/samba)
 
 [![Pasang Samba dengan YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=samba)
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -1,0 +1,51 @@
+<!--
+NB: Deze README is automatisch gegenereerd door <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+Hij mag NIET handmatig aangepast worden.
+-->
+
+# Samba voor Yunohost
+
+[![Integratieniveau](https://apps.yunohost.org/badge/integration/samba)](https://ci-apps.yunohost.org/ci/apps/samba/)
+![Mate van functioneren](https://apps.yunohost.org/badge/state/samba)
+![Onderhoudsstatus](https://apps.yunohost.org/badge/maintained/samba)
+
+[![Samba met Yunohost installeren](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=samba)
+
+*[Deze README in een andere taal lezen.](./ALL_README.md)*
+
+> *Met dit pakket kun je Samba snel en eenvoudig op een YunoHost-server installeren.*  
+> *Als je nog geen YunoHost hebt, lees dan [de installatiehandleiding](https://yunohost.org/install), om te zien hoe je 'm installeert.*
+
+## Overzicht
+
+This package allows you to create directories reachable on a private network.
+
+### Features
+
+- Create and name your directories;
+- Configure permissions for your directories thanks to the yunohost permission view;
+- Define readonly directories
+
+
+**Geleverde versie:** 4.13.13~ynh4
+## Documentatie en bronnen
+
+- Officiele website van de app: <https://www.samba.org/>
+- Officiele beheerdersdocumentatie: <https://www.samba.org/samba/docs/>
+- Upstream app codedepot: <https://git.samba.org/?p=samba.git;a=summary>
+- YunoHost-store: <https://apps.yunohost.org/app/samba>
+- Meld een bug: <https://github.com/YunoHost-Apps/samba_ynh/issues>
+
+## Ontwikkelaarsinformatie
+
+Stuur je pull request alsjeblieft naar de [`testing`-branch](https://github.com/YunoHost-Apps/samba_ynh/tree/testing).
+
+Om de `testing`-branch uit te proberen, ga als volgt te werk:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/samba_ynh/tree/testing --debug
+of
+sudo yunohost app upgrade samba -u https://github.com/YunoHost-Apps/samba_ynh/tree/testing --debug
+```
+
+**Verdere informatie over app-packaging:** <https://yunohost.org/packaging_apps>

--- a/README_pl.md
+++ b/README_pl.md
@@ -1,0 +1,51 @@
+<!--
+To README zostało automatycznie wygenerowane przez <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+Nie powinno być ono edytowane ręcznie.
+-->
+
+# Samba dla YunoHost
+
+[![Poziom integracji](https://apps.yunohost.org/badge/integration/samba)](https://ci-apps.yunohost.org/ci/apps/samba/)
+![Status działania](https://apps.yunohost.org/badge/state/samba)
+![Status utrzymania](https://apps.yunohost.org/badge/maintained/samba)
+
+[![Zainstaluj Samba z YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=samba)
+
+*[Przeczytaj plik README w innym języku.](./ALL_README.md)*
+
+> *Ta aplikacja pozwala na szybką i prostą instalację Samba na serwerze YunoHost.*  
+> *Jeżeli nie masz YunoHost zapoznaj się z [poradnikiem](https://yunohost.org/install) instalacji.*
+
+## Przegląd
+
+This package allows you to create directories reachable on a private network.
+
+### Features
+
+- Create and name your directories;
+- Configure permissions for your directories thanks to the yunohost permission view;
+- Define readonly directories
+
+
+**Dostarczona wersja:** 4.13.13~ynh4
+## Dokumentacja i zasoby
+
+- Oficjalna strona aplikacji: <https://www.samba.org/>
+- Oficjalna dokumentacja dla administratora: <https://www.samba.org/samba/docs/>
+- Repozytorium z kodem źródłowym: <https://git.samba.org/?p=samba.git;a=summary>
+- Sklep YunoHost: <https://apps.yunohost.org/app/samba>
+- Zgłaszanie błędów: <https://github.com/YunoHost-Apps/samba_ynh/issues>
+
+## Informacje od twórców
+
+Wyślij swój pull request do [gałęzi `testing`](https://github.com/YunoHost-Apps/samba_ynh/tree/testing).
+
+Aby wypróbować gałąź `testing` postępuj zgodnie z instrukcjami:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/samba_ynh/tree/testing --debug
+lub
+sudo yunohost app upgrade samba -u https://github.com/YunoHost-Apps/samba_ynh/tree/testing --debug
+```
+
+**Więcej informacji o tworzeniu paczek aplikacji:** <https://yunohost.org/packaging_apps>

--- a/README_ru.md
+++ b/README_ru.md
@@ -5,7 +5,9 @@
 
 # Samba для YunoHost
 
-[![Уровень интеграции](https://dash.yunohost.org/integration/samba.svg)](https://ci-apps.yunohost.org/ci/apps/samba/) ![Состояние работы](https://ci-apps.yunohost.org/ci/badges/samba.status.svg) ![Состояние сопровождения](https://ci-apps.yunohost.org/ci/badges/samba.maintain.svg)
+[![Уровень интеграции](https://apps.yunohost.org/badge/integration/samba)](https://ci-apps.yunohost.org/ci/apps/samba/)
+![Состояние работы](https://apps.yunohost.org/badge/state/samba)
+![Состояние сопровождения](https://apps.yunohost.org/badge/maintained/samba)
 
 [![Установите Samba с YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=samba)
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -5,7 +5,9 @@
 
 # YunoHost 上的 Samba
 
-[![集成程度](https://dash.yunohost.org/integration/samba.svg)](https://ci-apps.yunohost.org/ci/apps/samba/) ![工作状态](https://ci-apps.yunohost.org/ci/badges/samba.status.svg) ![维护状态](https://ci-apps.yunohost.org/ci/badges/samba.maintain.svg)
+[![集成程度](https://apps.yunohost.org/badge/integration/samba)](https://ci-apps.yunohost.org/ci/apps/samba/)
+![工作状态](https://apps.yunohost.org/badge/state/samba)
+![维护状态](https://apps.yunohost.org/badge/maintained/samba)
 
 [![使用 YunoHost 安装 Samba](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=samba)
 

--- a/conf/share-smb.conf
+++ b/conf/share-smb.conf
@@ -11,3 +11,5 @@
    recycle:repository = .recycle
    recycle:keeptree = yes
    recycle:versions = yes
+   recycle:directory_mode = 0770
+   recycle:subdir_mode: 0770


### PR DESCRIPTION
## Problem

If a dir is deleted, with new samba (on bookworm) the directory are not traversable due to a mask:--- issue. So we get an error like:
```
opendir(DATADIR_PATH/.recycle/subpath): Failed to open directory: Permission denied at /var/www/nextcloud/lib/private/Files/Storage/Local.php#164 
```

## Solution

Here we suggest to set new permission settings with vfs recycle subtree

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

